### PR TITLE
Allow saving as .srt for subtitles

### DIFF
--- a/main.py
+++ b/main.py
@@ -333,11 +333,11 @@ def _transcribe() -> Tuple[str, str]:
 			audio_name = os.path.basename(g_params["audio_path"]).split(".")[0]
 			save_name = f"{audio_name}_timestamps." + align_format
 		else:
-			save_name = "_timestamps." + align_format
+			save_name = "timestamps." + align_format
 		if align_format == "json":
 			save_alignments_to_json(aligned_result, save_dir, save_name)
 		elif align_format == "srt":
-			subtitles = alignments2subtitles(aligned_result["segments"])
+			subtitles = alignments2subtitles(aligned_result["segments"], max_line_length=50)
 			save_alignments_to_srt(subtitles, save_dir, save_name)
 	if g_params["release_memory"]:
 		release_align()


### PR DESCRIPTION
Added option to choose saving timestamps as `.json` or `.srt` (this last one for subtitles), as suggested in #11.
Note: saved subtitles in `.srt` may be spitted into multiple lines for convenience, however post processing should be applied if these are to be used in videos, as in some cases timestamps can be too long due to how WhisperX's VAD works, and may cover a big part of the video, or other issues.