### PR TITLE
Patch cuda 11.x not working on Windows after CTranslate2 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A simple GUI made with `gradio` to use Whisper.
 - `git` installed and added to PATH. See [instructions](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
 - `ffmpeg` installed and added to PATH. See instructions for [Windows](https://phoenixnap.com/kb/ffmpeg-windows), [Linux](https://phoenixnap.com/kb/install-ffmpeg-ubuntu) or [macOS](https://phoenixnap.com/kb/ffmpeg-mac).
 
+Optionally, to use GPU on Windows:
+- CUDA version ≥12.0. Install from [Nvidia's official site](https://developer.nvidia.com/cuda-downloads).
+
 ## Set up
 - In **Windows**, run the `whisper-gui.bat` file. In **Linux / macOS** run the `whisper-gui.sh` file. Follow the instructions and let the script install the necessary dependencies. After the process, it will run the GUI in a new browser tab.
 


### PR DESCRIPTION
After CTranslate2 new release 4.0.0, bugs appeared when running WhisperX on Windows on GPU, with a cuda 11.x, as discussed in this issue: 
https://github.com/Pikurrot/whisper-gui/issues/15#issuecomment-1967623103.

For now, the most stable and recommended solution is to install the latest Nvidia CUDA version (≥12.0), as suggested here: https://github.com/OpenNMT/CTranslate2/issues/1630.