### PR TITLE
update dependencies for working deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -23,7 +23,7 @@ RUN mkdir -p models outputs configs temp .cache && \
     chmod -R 777 models outputs configs temp .cache
 
 # Set cache directory environment variables
-ENV TRANSFORMERS_CACHE=/app/.cache
+ENV HF_HOME=/app/.cache
 ENV HF_HOME=/app/.cache
 ENV XDG_CACHE_HOME=/app/.cache
 ENV MPLCONFIGDIR=/app/.cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,14 @@ version: '3.8'
 
 services:
   whisper-gui:
+    # image: 3x3cut0r/whisper-gui:latest
     build: .
     ports:
       - "7860:7860"
     volumes:
       - ./models:/app/models  # Persist downloaded models
       - ./outputs:/app/outputs  # Store output files
-      - ./configs:/app/configs  # Configuration files
-      - ./temp:/app/temp  # Temporary files
     environment:
       - PYTHONUNBUFFERED=1
-    platform: linux/arm64  # Specify platform for M1/M2/M3 Macs
     user: "${UID:-1000}:${GID:-1000}"  # Run as current user
-    init: true  # Proper signal handling 
+    init: true  # Proper signal handling

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-gradio>=3.50.2
+gradio>=5
 torch>=2.0.0
-git+https://github.com/m-bain/whisperx.git
+whisperx
 numpy>=1.24.3
 tqdm>=4.65.0 


### PR DESCRIPTION
Otherwise one runs into #38

Having the platform arch in the docker compose file make `docker compose build` fail on amd64, while `docker build -t .` works. This is also cumbersome and should be avoided.